### PR TITLE
Re-activate tests

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -11,8 +11,7 @@ BuildParameters.SetParameters(context: Context,
                             appVeyorAccountName: "cakecontrib",
                             shouldRunDotNetCorePack: true,
                             shouldRunDupFinder: false,
-                            shouldRunInspectCode: false,
-                            testFilePattern: "DO_NOT_RUN_TESTS");
+                            shouldRunInspectCode: false);
 
 BuildParameters.PrintParameters(Context);
 

--- a/src/Cake.AppVeyor.Tests/Keys.cs
+++ b/src/Cake.AppVeyor.Tests/Keys.cs
@@ -21,7 +21,7 @@ namespace Cake.AppVeyor.Tests
 
                     // Next check for an environment variable
                     if (string.IsNullOrEmpty(appVeyorApiToken))
-                        appVeyorApiToken = Environment.GetEnvironmentVariable("appveyor_api_token");
+                        appVeyorApiToken = Environment.GetEnvironmentVariable("test_appveyor_api_token");
 
                     // Finally use the const value
                     if (string.IsNullOrEmpty(appVeyorApiToken))


### PR DESCRIPTION
Using a different environment variable name for the app veyor api key used for running tests so it doesn't conflict with the existing variable setup by cake-contrib.