### PR TITLE
Pin Cake.Recipe to stable 4.0.0 (align with Cake.7zip canonical)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "3.2.0",
+      "version": "2.3.0",
       "commands": [
         "dotnet-cake"
       ],

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,7 +81,7 @@ jobs:
       uses: cake-build/cake-action@d218f1133bb74a1df0b08c89cfd8fc100c09e1a0 # v3
       with:
         script-path: recipe.cake
-        target: DotNet-Build
+        target: DotNetCore-Build
         cake-version: tool-manifest
       env:
         COMPlus_DbgEnableMiniDump: 1

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins/nuget/v3/index.json?package=Cake.Recipe&version=4.1.0-alpha0042
+#load nuget:?package=Cake.Recipe&version=4.0.0
 
 Environment.SetVariableNames();
 
@@ -9,7 +9,7 @@ BuildParameters.SetParameters(context: Context,
                             repositoryOwner: "cake-contrib",
                             repositoryName: "Cake.AppVeyor",
                             appVeyorAccountName: "cakecontrib",
-                            shouldRunDotNetPack: true,
+                            shouldRunDotNetCorePack: true,
                             shouldRunInspectCode: false,
                             testFilePattern: "DO_NOT_RUN_TESTS",
                             preferredBuildProviderType: BuildProviderType.GitHubActions);
@@ -20,4 +20,4 @@ ToolSettings.SetToolSettings(context: Context,
                             testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[FakeItEasy]*",
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
                             testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
-Build.RunDotNet();
+Build.RunDotNetCore();


### PR DESCRIPTION
## Description

Switches `recipe.cake` to load Cake.Recipe **4.0.0** from public NuGet, replacing the prior load of `4.1.0-alpha0042` from the cake-contrib Azure DevOps prerelease feed. Aligns the pinning with [`cake-contrib/Cake.7zip`](https://github.com/cake-contrib/Cake.7zip)'s canonical setup (`develop`).

Follow-up to the merged baseline PR #167.

## Related Issue

(none — proactive maintenance)

## Motivation and Context

Cross-addin baseline work uncovered that several cake-contrib addins consume Cake.Recipe via the cake-contrib Azure DevOps prerelease feed at version `4.1.0-alpha0042`, while the canonical Cake.7zip uses Cake.Recipe `4.0.0` from public NuGet. Pinning to a published stable version reduces drift, removes a private-feed dependency, and means consumers (or fresh clones) can build out-of-the-box without configuring the Azure DevOps feed.

Cake.Recipe 4.0.0 was built against Cake.Common 2.x. To match, this PR also realigns `cake.tool` to 2.3.0 (Cake.7zip canonical) — same Cake major.

## How Has This Been Tested?

- Local diff against Cake.7zip's canonical `recipe.cake`, `.config/dotnet-tools.json`, and `codeql-analysis.yml` confirmed the pinning matches.
- Verified separately on Cake.Discord (PR #94) that this exact combination — Cake.Recipe 4.0.0 + cake.tool 2.3.0 + the older `Build.RunDotNetCore()` / `shouldRunDotNetCorePack` API names + `target: DotNetCore-Build` in CodeQL — produces a fully green CI (build on Linux + Windows + CodeQL).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(None of the above — build pinning only. The addin's published artefact is unaffected.)

## Per-file changes

| File | Change |
|---|---|
| `recipe.cake` | Load `Cake.Recipe&version=4.0.0` from `nuget:?` (public NuGet) instead of the cake-contrib Azure DevOps prerelease feed at `4.1.0-alpha0042`. |
| `recipe.cake` | `shouldRunDotNetPack` → `shouldRunDotNetCorePack` (older API name; alpha-only `shouldRunDotNetPack` doesn't exist in 4.0.0). |
| `recipe.cake` | `Build.RunDotNet()` → `Build.RunDotNetCore()` (older API name). |
| `.config/dotnet-tools.json` | `cake.tool` 3.2.0 → 2.3.0 (matching Cake.7zip canonical). The matching Cake.Common 2.x is what Cake.Recipe 4.0.0 was built against. |
| `.github/workflows/codeql-analysis.yml` | Build target `DotNet-Build` → `DotNetCore-Build` (older task name). |

## Notes

- Local exercise scripts (`test.cake`) that need to load the addin's net8/9/10 DLL should be invoked via the **global** `cake.tool` (`& "$env:USERPROFILE\.dotnet\tools\dotnet-cake.exe" test.cake`). The local-manifest cake.tool 2.3.0 stays compatible with the CI build script.
- A future bump to a hypothetical Cake.Recipe stable that supports Cake 6 will allow bumping cake.tool back to a newer version. Until then, the 4.0.0 + 2.3.0 pair is the right alignment.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed (verified the same pinning on Cake.Discord — Linux + Windows + CodeQL all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)